### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ If you wish to load the Localize script using [Subresource Integrity](https://de
 
 
 # Release Notes
+## Version 493 - August 28, 2024
+* **[Fix]**: Allow for mixed case languages and locales when setting through ljs parameter. For example, ljs=en-UK and ljs=en-uk are both acceptable.
+```
+// Script tag without SRI
+<script src="https://global.localizecdn.com/localize.493.js"></script>
+
+// Script tag with SRI
+<script src="https://global.localizecdn.com/localize.493.js" integrity="sha512-wAEFhVJSg5EpSjly8iMbPvgg9A987KgpmyMFkbNcobGLiHf2rFb5IEgS785cRulLvtVeE2R/KPcG3O/4zwiZOw==" crossorigin="anonymous"></script>
+```
+
 ## Version 492 - August 26, 2024
 * **[Fix]**: Fixes issue where turning off widget while using targetLanguage parameter caused translations to not be delivered to websites.
 ```


### PR DESCRIPTION
Allow for mixed case languages and locales when setting through ljs parameter. For example, ljs=en-UK and ljs=en-uk are both acceptable.